### PR TITLE
Use resource-disposer to help release resources reliably

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
  <artifactId>foreman-node-sharing</artifactId>
  <packaging>hpi</packaging>
  <name>Foreman Node Sharing Plugin</name>
- <version>1.1.0-SNAPSHOT</version>
+ <version>1.1.1-SNAPSHOT</version>
  <description>Attach Foreman Shared Resources as Jenkins Nodes</description>
  <url>https://wiki.jenkins-ci.org/display/JENKINS/Foreman+Node+Sharing+Plugin</url>
 
@@ -71,6 +71,11 @@
  </properties>
 
  <dependencies>
+  <dependency>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>resource-disposer</artifactId>
+    <version>0.1</version>
+  </dependency>
   <dependency>
    <groupId>org.apache.commons</groupId>
    <artifactId>commons-lang3</artifactId>

--- a/src/main/java/com/redhat/foreman/DisposableImpl.java
+++ b/src/main/java/com/redhat/foreman/DisposableImpl.java
@@ -1,0 +1,40 @@
+package com.redhat.foreman;
+
+import org.apache.log4j.Logger;
+import org.jenkinsci.plugins.resourcedisposer.Disposable;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Created by shebert on 27/09/16.
+ */
+public class DisposableImpl implements Disposable {
+
+    private final String cloudName;
+    private final String name;
+    private static final Logger LOGGER = Logger.getLogger(DisposableImpl.class);
+
+    public DisposableImpl(String cloudName, String name) {
+        this.cloudName = cloudName;
+        this.name = name;
+    }
+
+    @Nonnull
+    @Override
+    public State dispose() throws Exception {
+        ForemanSharedNodeCloud cloud = ForemanSharedNodeCloud.getByName(cloudName);
+        if (cloud != null) {
+            cloud.getForemanAPI().release(name);
+            return State.PURGED;
+        } else {
+            LOGGER.warn("Foreman Shared Node " + name + " is not part of a Foreman Shared Node Cloud");
+        }
+        return State.TO_DISPOSE;
+    }
+
+    @Nonnull
+    @Override
+    public String getDisplayName() {
+        return "Dispose Foreman Shared Node Cloud " + cloudName + " - Shared Node: " + name;
+    }
+}

--- a/src/main/java/com/redhat/foreman/ForemanSharedNode.java
+++ b/src/main/java/com/redhat/foreman/ForemanSharedNode.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.util.List;
 
 import org.apache.log4j.Logger;
+import org.jenkinsci.plugins.resourcedisposer.AsyncResourceDisposer;
 
 /**
  * Foreman Shared Node.
@@ -26,12 +27,8 @@ public class ForemanSharedNode extends AbstractCloudSlave {
 
     @Override
     public void terminate() throws InterruptedException, IOException {
-        ForemanSharedNodeCloud cloud = ForemanSharedNodeCloud.getByName(cloudName);
-        if (cloud != null) {
-            cloud.getForemanAPI().release(name);
-        } else {
-            LOGGER.warn("Foreman Shared Node " + name + " is not part of a Foreman Shared Node Cloud");
-        }
+        DisposableImpl disposable = new DisposableImpl(cloudName, name);
+        AsyncResourceDisposer.get().dispose(disposable);
         super.terminate();
     }
 


### PR DESCRIPTION
If the connection to Foreman is lost or the plugin can no
longer release the resource, the resource-disposer plugin
will continue to attempt to dispose of it.

[FIXES JENKINS-38100]