### PR TITLE
Show compatible hosts on dedicated page instead of configure page

### DIFF
--- a/src/main/java/com/redhat/foreman/ForemanSharedNodeCloud.java
+++ b/src/main/java/com/redhat/foreman/ForemanSharedNodeCloud.java
@@ -50,6 +50,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.jenkinsci.plugins.resourcedisposer.AsyncResourceDisposer;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -526,7 +528,8 @@ public class ForemanSharedNodeCloud extends Cloud {
         hostsMap.set(new HashMap<String, String>());
     }
 
-    private Map<String, String> getHostsMapData() {
+    @Restricted(DoNotUse.class) // index.jelly
+    public Map<String, String> getHostsMapData() {
         if (hostsMap == null) {
             hostsMap = new AtomicReference<Map<String, String>>(new HashMap<String, String>());
         }
@@ -586,56 +589,6 @@ public class ForemanSharedNodeCloud extends Cloud {
                 }
             }
             return FormValidation.error(Messages.InvalidURI());
-        }
-
-        /**
-         * Check for compatible hosts.
-         *
-         * @param url      url.
-         * @param user     user.
-         * @param password password.
-         * @return Form Validation.
-         * @throws ServletException if occurs.
-         */
-        public FormValidation doCheckForCompatibleHosts(@QueryParameter("url") String url,
-                                                        @QueryParameter("user") String user,
-                                                        @QueryParameter("password") Secret password) throws ServletException {
-
-            FormValidation testConn = this.doTestConnection(url, user, password);
-            if (testConn.kind != FormValidation.Kind.OK) {
-                return testConn;
-            }
-
-            Set<String> hosts = checkForCompatibleHosts(url, user, password);
-            StringBuffer hostsMessage = new StringBuffer();
-            hostsMessage.append(Messages.CheckCompatibleHostsOK() + "<br><br>");
-            if (hosts == null || hosts.isEmpty()) {
-                return FormValidation.error(Messages.CheckCompatibleHostsFailure());
-            } else {
-                for (String host : hosts) {
-                    hostsMessage.append("<font face=\"verdana\" color=\"green\">" + host + "</font><br>");
-                }
-                return FormValidation.okWithMarkup(hostsMessage.toString());
-            }
-        }
-
-        /**
-         * Call API to check for compatible hosts.
-         *
-         * @param url      url.
-         * @param user     user.
-         * @param password password.
-         * @return List of hosts.
-         */
-        private Set<String> checkForCompatibleHosts(String url, String user, Secret password) {
-            ForemanAPI testApi = new ForemanAPI(url, user, password);
-            Map<String, String> hosts = new HashMap<String, String>();
-            try {
-                hosts = testApi.getCompatibleHosts();
-            } catch (Exception e) {
-                LOGGER.log(Level.SEVERE, "Unhandled exception in checkForCompatibleHosts: ", e);
-            }
-            return hosts.keySet();
         }
 
         /**

--- a/src/main/resources/com/redhat/foreman/ForemanSharedNodeCloud/config.jelly
+++ b/src/main/resources/com/redhat/foreman/ForemanSharedNodeCloud/config.jelly
@@ -1,6 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-    xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
 
 <f:section title="Foreman Parameters">
   <f:entry title="${%Name}" field="cloudName">
@@ -18,9 +17,8 @@
 </f:section>
   
   <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="url,user,password" />
-  <f:validateButton title="${%Check for Compatible Foreman Hosts}" progress="${%Checking...}" method="checkForCompatibleHosts" with="url,user,password" />
   
-<f:section title="Slave Parameters">
+<f:section title="Node Parameters">
   <f:entry title="${%Credentials}" field="credentialsId">
     <c:select/>
   </f:entry>

--- a/src/main/resources/com/redhat/foreman/ForemanSharedNodeCloud/index.jelly
+++ b/src/main/resources/com/redhat/foreman/ForemanSharedNodeCloud/index.jelly
@@ -1,0 +1,45 @@
+<!--
+The MIT License
+
+Copyright (c) 2016 Red Hat, inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+    <l:layout title="${it.fullDisplayName}">
+        <st:include page="sidepanel.jelly" it="${app}"/>
+        <l:main-panel>
+            <h1>${it.displayName}</h1>
+            <h2>${%All hosts in the pool}</h2>
+            <table class="pane sortable bigtable">
+                <tr>
+                    <th>Name</th><th>Labels</th>
+                </tr>
+                <j:forEach var="host" items="${it.hostsMapData.entrySet()}">
+                    <tr>
+                        <td>${host.key}</td>
+                        <td>${host.value}</td>
+                    </tr>
+                </j:forEach>
+            </table>
+        </l:main-panel>
+    </l:layout>
+</j:jelly>


### PR DESCRIPTION
Move list of running hosts to dedicated page so users do not have to visit `/configure` for that. For now, there is no link that points to cloud main page.