### PR TITLE
Reworked provisioning

### DIFF
--- a/src/main/java/com/redhat/foreman/ForemanCleanupThread.java
+++ b/src/main/java/com/redhat/foreman/ForemanCleanupThread.java
@@ -45,7 +45,7 @@ public final class ForemanCleanupThread extends AsyncPeriodicWork {
 
     @Override
     public long getRecurrencePeriod() {
-        return MIN;
+        return MIN / 4;
     }
 
     @Override

--- a/src/main/java/com/redhat/foreman/ForemanSharedNodeCloud.java
+++ b/src/main/java/com/redhat/foreman/ForemanSharedNodeCloud.java
@@ -182,7 +182,7 @@ public class ForemanSharedNodeCloud extends Cloud {
 
     @Override
     public boolean canProvision(Label label) {
-        LOGGER.finer("canProvision() asked for label '" + label + "'");
+        LOGGER.finer("canProvision() asked for label '" + (label == null ? "" : label) + "'");
         long time = System.currentTimeMillis();
 
         for (Map.Entry<Set<LabelAtom>, HostInfo> host: hostsMap.entrySet()) {
@@ -210,7 +210,7 @@ public class ForemanSharedNodeCloud extends Cloud {
 
         final long start_time = System.currentTimeMillis();
 
-        LOGGER.info("Request to provion label: '" + (label == null ? "" : label.toString()) + "'");
+        LOGGER.info("Request to provion label: '" + (label == null ? "" : label) + "'");
 
         if (excessWorkload > 0
                 && !Jenkins.getInstance().isQuietingDown()
@@ -218,7 +218,7 @@ public class ForemanSharedNodeCloud extends Cloud {
                 && canProvision(label)) {
             try {
 
-                LOGGER.info("Try to provion label: '" + (label == null ? "" : label.toString()) + "' in " +
+                LOGGER.info("Try to provion label: '" + (label == null ? "" : label) + "' in " +
                         Util.getTimeSpanString(System.currentTimeMillis() - start_time));
 
                 final ProvisioningActivity.Id id = new ProvisioningActivity.Id(name, null);

--- a/src/main/java/com/redhat/foreman/ForemanSharedNodeCloud.java
+++ b/src/main/java/com/redhat/foreman/ForemanSharedNodeCloud.java
@@ -189,7 +189,7 @@ public class ForemanSharedNodeCloud extends Cloud {
 
             try {
                 if (label.matches(host.getKey())) {
-                    LOGGER.finer("canProvision returns True in "
+                    LOGGER.info("canProvision returns True in "
                             + Util.getTimeSpanString(System.currentTimeMillis() - time));
                     return true;
                 }
@@ -198,7 +198,7 @@ public class ForemanSharedNodeCloud extends Cloud {
                 continue;
             }
         }
-        LOGGER.finer("canProvision returns False in "
+        LOGGER.info("canProvision returns False in "
                 + Util.getTimeSpanString(System.currentTimeMillis() - time));
         return false;
     }
@@ -207,32 +207,87 @@ public class ForemanSharedNodeCloud extends Cloud {
     @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public Collection<PlannedNode> provision(final @CheckForNull Label label, int excessWorkload) {
         Collection<NodeProvisioner.PlannedNode> result = new ArrayList<NodeProvisioner.PlannedNode>();
+
+        final long start_time = System.currentTimeMillis();
+
         if (excessWorkload > 0
                 && !Jenkins.getInstance().isQuietingDown()
                 && !Jenkins.getInstance().isTerminating()
                 && canProvision(label)) {
             try {
                 final ProvisioningActivity.Id id = new ProvisioningActivity.Id(name, null);
-                Future<Node> futurePlannedNode = Computer.threadPoolForRemoting.submit(new Callable<Node>() {
-                    public Node call() throws Exception {
-                        Node node = null;
-                        try {
-                            node = provision(label, id);
-                        } catch (Exception e) {
-                            LOGGER.log(Level.SEVERE, "Unhandled exception in provision(): ", e);
-                            throw (AbortException) new AbortException().initCause(e);
+
+                for (final HostInfo hi : getHostsToReserve(label)) {
+                    try {
+                        final HostInfo host = getForemanAPI().reserveHost(hi);
+                        if (host != null) {
+
+                            LOGGER.info("Reserved host '" + host.getName() + "' in " +
+                                    Util.getTimeSpanString(System.currentTimeMillis() - start_time));
+
+                            Future<Node> futurePlannedNode = Computer.threadPoolForRemoting.submit(new Callable<Node>() {
+                                public Node call() throws Exception {
+
+                                    LOGGER.info("Trying to provision Foreman Shared Node '" + host.getName() + "' in " +
+                                            Util.getTimeSpanString(System.currentTimeMillis() - start_time));
+
+                                    Node node = null;
+                                    try {
+                                        String labelsForHost = host.getLabels();
+                                        String remoteFS = host.getRemoteFs();
+
+                                        if (launcherFactory == null) {
+                                            launcherFactory = new ForemanSSHComputerLauncherFactory(SSH_DEFAULT_PORT,
+                                                    credentialsId, sshConnectionTimeOut);
+                                        }
+
+                                        node = new ForemanSharedNode(
+                                                id.named(host.getName()),
+                                                labelsForHost,
+                                                remoteFS,
+                                                launcherFactory.getForemanComputerLauncher(host),
+                                                new CloudRetentionStrategy(1),
+                                                Collections.<NodeProperty<?>>emptyList());
+                                    } catch (Exception e) {
+                                        LOGGER.log(Level.SEVERE, "Unhandled exception in provision(): ", e);
+                                        addDisposableEvent(cloudName, host.getName());
+                                        throw (AbortException) new AbortException().initCause(e);
+                                    } catch (Error e) {
+                                        addDisposableEvent(cloudName, host.getName());
+                                        throw e;
+                                    } catch (Throwable e) {
+                                        LOGGER.log(Level.WARNING, "Exception encountered when trying to create shared node. ", e);
+                                        addDisposableEvent(cloudName, host.getName());
+                                    }
+
+                                    LOGGER.info("Provisioned Foreman Shared Node '" + host.getName() + "' in " +
+                                            Util.getTimeSpanString(System.currentTimeMillis() - start_time));
+
+                                    return node;
+                                }
+                            });
+                            result.add(new TrackedPlannedNode(id, 1, futurePlannedNode));
+
+                            LOGGER.info("Return node collection with one element in " +
+                                    Util.getTimeSpanString(System.currentTimeMillis() - start_time));
+
+                            return result;
                         }
-                        if (node == null) {
-                            throw new AbortException("No Foreman resources available");
-                        }
-                        return node;
+                    } catch (Error e) {
+                        throw e;
+                    } catch (Throwable e) {
+                        addDisposableEvent(cloudName, hi.getName());
+                        LOGGER.log(Level.WARNING, "Exception encountered when trying to create shared node. ", e);
                     }
-                });
-                result.add(new TrackedPlannedNode(id, 1, futurePlannedNode));
+                }
             } catch (Exception e) {
                 LOGGER.log(Level.SEVERE, "Unhandled exception in provision(): ", e);
             }
         }
+
+        LOGGER.info("Returned empty node collection in " +
+                Util.getTimeSpanString(System.currentTimeMillis() - start_time));
+
         return result;
     }
 
@@ -245,48 +300,48 @@ public class ForemanSharedNodeCloud extends Cloud {
      * @return a Foreman Slave.
      * @throws Exception if occurs.
      */
-    @CheckForNull
-    private ForemanSharedNode provision(@CheckForNull Label label, ProvisioningActivity.Id id) throws Exception {
-        LOGGER.finer("Trying to provision Foreman Shared Node for '" + label + "'");
-        ForemanAPI foreman = getForemanAPI();
-        try {
-            for (HostInfo hi : getHostsToReserve(label)) {
-
-                hi = foreman.reserveHost(hi);
-                if (hi != null) {
-                    try {
-                        String labelsForHost = hi.getLabels();
-                        String remoteFS = hi.getRemoteFs();
-
-                        if (launcherFactory == null) {
-                            launcherFactory = new ForemanSSHComputerLauncherFactory(SSH_DEFAULT_PORT, credentialsId, sshConnectionTimeOut);
-                        }
-
-                        LOGGER.finer("Returning a ForemanSharedNode for " + hi.getName());
-                        return new ForemanSharedNode(
-                                id.named(hi.getName()),
-                                labelsForHost,
-                                remoteFS,
-                                launcherFactory.getForemanComputerLauncher(hi),
-                                new CloudRetentionStrategy(1),
-                                Collections.<NodeProperty<?>>emptyList());
-                    } catch (Error e) {
-                        throw e;
-                    } catch (Throwable e) {
-                        addDisposableEvent(cloudName, hi.getName());
-                    }
-                }
-            }
-        } catch (Error e) {
-            throw e;
-        } catch (Throwable e) {
-            LOGGER.log(Level.WARNING, "Exception encountered when trying to create shared node. ", e);
-        }
-
-        // Something has changed and there are now no resources available...
-        LOGGER.finer("No Foreman resources available...");
-        return null;
-    }
+//    @CheckForNull
+//    private ForemanSharedNode provision(@CheckForNull Label label, ProvisioningActivity.Id id) throws Exception {
+//        LOGGER.finer("Trying to provision Foreman Shared Node for '" + label + "'");
+//        ForemanAPI foreman = getForemanAPI();
+//        try {
+//            for (HostInfo hi : getHostsToReserve(label)) {
+//
+//                hi = foreman.reserveHost(hi);
+//                if (hi != null) {
+//                    try {
+//                        String labelsForHost = hi.getLabels();
+//                        String remoteFS = hi.getRemoteFs();
+//
+//                        if (launcherFactory == null) {
+//                            launcherFactory = new ForemanSSHComputerLauncherFactory(SSH_DEFAULT_PORT, credentialsId, sshConnectionTimeOut);
+//                        }
+//
+//                        LOGGER.finer("Returning a ForemanSharedNode for " + hi.getName());
+//                        return new ForemanSharedNode(
+//                                id.named(hi.getName()),
+//                                labelsForHost,
+//                                remoteFS,
+//                                launcherFactory.getForemanComputerLauncher(hi),
+//                                new CloudRetentionStrategy(1),
+//                                Collections.<NodeProperty<?>>emptyList());
+//                    } catch (Error e) {
+//                        throw e;
+//                    } catch (Throwable e) {
+//                        addDisposableEvent(cloudName, hi.getName());
+//                    }
+//                }
+//            }
+//        } catch (Error e) {
+//            throw e;
+//        } catch (Throwable e) {
+//            LOGGER.log(Level.WARNING, "Exception encountered when trying to create shared node. ", e);
+//        }
+//
+//        // Something has changed and there are now no resources available...
+//        LOGGER.finer("No Foreman resources available...");
+//        return null;
+//    }
 
     /**
      * Get the list of hosts available for reservation for the label.

--- a/src/main/java/com/redhat/foreman/ForemanSharedNodeCloud.java
+++ b/src/main/java/com/redhat/foreman/ForemanSharedNodeCloud.java
@@ -311,58 +311,6 @@ public class ForemanSharedNodeCloud extends Cloud {
     }
 
     /**
-     * Perform the provisioning. This uses the Foreman hosts_reserve plugin to "lock"
-     * a host for this requesting master.
-     *
-     * @param label linked Jenkins Label.
-     * @param id
-     * @return a Foreman Slave.
-     * @throws Exception if occurs.
-     */
-//    @CheckForNull
-//    private ForemanSharedNode provision(@CheckForNull Label label, ProvisioningActivity.Id id) throws Exception {
-//        LOGGER.finer("Trying to provision Foreman Shared Node for '" + label + "'");
-//        ForemanAPI foreman = getForemanAPI();
-//        try {
-//            for (HostInfo hi : getHostsToReserve(label)) {
-//
-//                hi = foreman.reserveHost(hi);
-//                if (hi != null) {
-//                    try {
-//                        String labelsForHost = hi.getLabels();
-//                        String remoteFS = hi.getRemoteFs();
-//
-//                        if (launcherFactory == null) {
-//                            launcherFactory = new ForemanSSHComputerLauncherFactory(SSH_DEFAULT_PORT, credentialsId, sshConnectionTimeOut);
-//                        }
-//
-//                        LOGGER.finer("Returning a ForemanSharedNode for " + hi.getName());
-//                        return new ForemanSharedNode(
-//                                id.named(hi.getName()),
-//                                labelsForHost,
-//                                remoteFS,
-//                                launcherFactory.getForemanComputerLauncher(hi),
-//                                new CloudRetentionStrategy(1),
-//                                Collections.<NodeProperty<?>>emptyList());
-//                    } catch (Error e) {
-//                        throw e;
-//                    } catch (Throwable e) {
-//                        addDisposableEvent(cloudName, hi.getName());
-//                    }
-//                }
-//            }
-//        } catch (Error e) {
-//            throw e;
-//        } catch (Throwable e) {
-//            LOGGER.log(Level.WARNING, "Exception encountered when trying to create shared node. ", e);
-//        }
-//
-//        // Something has changed and there are now no resources available...
-//        LOGGER.finer("No Foreman resources available...");
-//        return null;
-//    }
-
-    /**
      * Get the list of hosts available for reservation for the label.
      *
      * Since we are working with outdated data, client needs to check if hosts are free before allocating them.

--- a/src/main/java/com/redhat/foreman/ForemanSharedNodeCloud.java
+++ b/src/main/java/com/redhat/foreman/ForemanSharedNodeCloud.java
@@ -286,6 +286,11 @@ public class ForemanSharedNodeCloud extends Cloud {
                                     Util.getTimeSpanString(System.currentTimeMillis() - start_time));
 
                             return result;
+                        } else {
+
+                            LOGGER.info("Trying to reserve host '" + hi.getName() + "' FAILED in " +
+                                    Util.getTimeSpanString(System.currentTimeMillis() - start_time));
+
                         }
                     } catch (Error e) {
                         throw e;

--- a/src/main/java/com/redhat/foreman/ForemanSharedNodeCloud.java
+++ b/src/main/java/com/redhat/foreman/ForemanSharedNodeCloud.java
@@ -225,9 +225,6 @@ public class ForemanSharedNodeCloud extends Cloud {
 
                 for (final HostInfo hi : getHostsToReserve(label)) {
 
-                    LOGGER.info("Try to provision host '" + hi.getName() + "' in " +
-                            Util.getTimeSpanString(System.currentTimeMillis() - start_time));;
-
                     try {
 
                         LOGGER.info("Try to reserve host '" + hi.getName() + "' in " +

--- a/src/main/java/com/redhat/foreman/ForemanSharedNodeCloud.java
+++ b/src/main/java/com/redhat/foreman/ForemanSharedNodeCloud.java
@@ -188,7 +188,7 @@ public class ForemanSharedNodeCloud extends Cloud {
         for (Map.Entry<Set<LabelAtom>, HostInfo> host: hostsMap.entrySet()) {
 
             try {
-                if (label.matches(host.getKey())) {
+                if (label == null || label.matches(host.getKey())) {
                     LOGGER.info("canProvision returns True in "
                             + Util.getTimeSpanString(System.currentTimeMillis() - time));
                     return true;
@@ -210,15 +210,29 @@ public class ForemanSharedNodeCloud extends Cloud {
 
         final long start_time = System.currentTimeMillis();
 
+        LOGGER.info("Request to provion label: '" + (label == null ? "" : label.toString()) + "'");
+
         if (excessWorkload > 0
                 && !Jenkins.getInstance().isQuietingDown()
                 && !Jenkins.getInstance().isTerminating()
                 && canProvision(label)) {
             try {
+
+                LOGGER.info("Try to provion label: '" + (label == null ? "" : label.toString()) + "' in " +
+                        Util.getTimeSpanString(System.currentTimeMillis() - start_time));
+
                 final ProvisioningActivity.Id id = new ProvisioningActivity.Id(name, null);
 
                 for (final HostInfo hi : getHostsToReserve(label)) {
+
+                    LOGGER.info("Try to provision host '" + hi.getName() + "' in " +
+                            Util.getTimeSpanString(System.currentTimeMillis() - start_time));;
+
                     try {
+
+                        LOGGER.info("Try to reserve host '" + hi.getName() + "' in " +
+                                Util.getTimeSpanString(System.currentTimeMillis() - start_time));
+
                         final HostInfo host = getForemanAPI().reserveHost(hi);
                         if (host != null) {
 


### PR DESCRIPTION
The main aim of this rework is to avoid '"No Foreman resources available...' exception which occurred so many times obviously.

In one element structure `Collection<NodeProvisioner.PlannedNode>` we return a node which we reserve synchronously or we return an empty collection. The rest of provisioning procedure (including launching) is postponed to async thread like previously.

This rework also resolves other issue - when we were asked to provision label which we can but we don't have enough resources the procedure is stuck in our Foreman provider - now Jenkins can ask for that another provider.

Also added LOG messages for better tracking of provision timing.